### PR TITLE
Add version to DTOs including tests

### DIFF
--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataQuery.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataQuery.java
@@ -1,15 +1,35 @@
 package net.smartcosmos.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
+
+import java.beans.ConstructorProperties;
 
 @Data
-@Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataQuery {
+
+    private static final int VERSION = 1;
+
+    @Setter(AccessLevel.NONE)
+    private int version = VERSION; // just in case there is a default constructor sometime
+
     private String entityReferenceType;
     private String key;
     private String dataType;
     private String rawValue;
+
+    @Builder
+    @ConstructorProperties({"entityReferenceType", "key", "dataType", "rawValue"})
+    public MetadataQuery(String entityReferenceType, String key, String dataType, String rawValue) {
+        this.entityReferenceType = entityReferenceType;
+        this.key = key;
+        this.dataType = dataType;
+        this.rawValue = rawValue;
+
+        this.version = VERSION;
+    }
 }

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataResponse.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataResponse.java
@@ -1,13 +1,22 @@
 package net.smartcosmos.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
+
+import java.beans.ConstructorProperties;
 
 @Data
-@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MetadataResponse {
+
+    private static final int VERSION = 1;
+
+    @Setter(AccessLevel.NONE)
+    private int version = VERSION; // just in case there is a default constructor sometime
+
     private final String dataType;
     private final String entityReferenceType;
     private final String key;
@@ -16,5 +25,20 @@ public class MetadataResponse {
     private final String referenceUrn;
     private final String urn;
     private final String moniker;
+
+    @Builder
+    @ConstructorProperties({"dataType", "entityReferenceType", "key", "lastModifiedTimestamp", "rawValue", "referenceUrn", "urn", "moniker"})
+    public MetadataResponse(String dataType, String entityReferenceType, String key, Long lastModifiedTimestamp, String rawValue, String referenceUrn, String urn, String moniker) {
+        this.dataType = dataType;
+        this.entityReferenceType = entityReferenceType;
+        this.key = key;
+        this.lastModifiedTimestamp = lastModifiedTimestamp;
+        this.rawValue = rawValue;
+        this.referenceUrn = referenceUrn;
+        this.urn = urn;
+        this.moniker = moniker;
+
+        this.version = VERSION;
+    }
 }
 

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataUpsert.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataUpsert.java
@@ -1,17 +1,39 @@
 package net.smartcosmos.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
+
+import java.beans.ConstructorProperties;
 
 @Data
-@Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataUpsert {
+
+    private static final int VERSION = 1;
+
+    @Setter(AccessLevel.NONE)
+    private int version = VERSION; // just in case there is a default constructor sometime
+
     private String entityReferenceType;
     private String referenceUrn;
     private String dataType;
     private String key;
     private String rawValue;
     private String moniker;
+
+    @Builder
+    @ConstructorProperties({"entityReferenceType", "referenceUrn", "dataType", "key", "rawValue", "moniker"})
+    public MetadataUpsert(String entityReferenceType, String referenceUrn, String dataType, String key, String rawValue, String moniker) {
+        this.entityReferenceType = entityReferenceType;
+        this.referenceUrn = referenceUrn;
+        this.dataType = dataType;
+        this.key = key;
+        this.rawValue = rawValue;
+        this.moniker = moniker;
+
+        this.version = VERSION;
+    }
 }

--- a/src/test/java/net/smartcosmos/dto/metadata/MetadataQueryTest.java
+++ b/src/test/java/net/smartcosmos/dto/metadata/MetadataQueryTest.java
@@ -1,0 +1,34 @@
+package net.smartcosmos.dto.metadata;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class MetadataQueryTest {
+
+    @Test
+    public void thatVersionIsSet() {
+        MetadataQuery entity = MetadataQuery.builder().build();
+
+        assertNotNull(entity.getVersion());
+        assertEquals(1, entity.getVersion());
+    }
+
+    /**
+     * This actually tests if Lombok is properly used.
+     */
+    @Test
+    public void thatVersionHasNoSetter() {
+        Method getVersion = null;
+        try {
+            getVersion = MetadataQuery.class.getDeclaredMethod("setVersion", int.class);
+        } catch (NoSuchMethodException e) {
+            // that's what we expect
+        }
+        assertNull(getVersion);
+    }
+}

--- a/src/test/java/net/smartcosmos/dto/metadata/MetadataResponseTest.java
+++ b/src/test/java/net/smartcosmos/dto/metadata/MetadataResponseTest.java
@@ -1,0 +1,36 @@
+package net.smartcosmos.dto.metadata;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class MetadataResponseTest {
+
+    @Test
+    public void thatVersionIsSet() {
+        MetadataResponse entity = MetadataResponse.builder().build();
+
+        assertNotNull(entity.getVersion());
+        assertEquals(1, entity.getVersion());
+    }
+
+    /**
+     * This actually tests if Lombok is properly used.
+     */
+    @Test
+    public void thatVersionHasNoSetter() {
+        Method getVersion = null;
+        try {
+            getVersion = MetadataResponse.class.getDeclaredMethod("setVersion", int.class);
+        } catch (NoSuchMethodException e) {
+            // that's what we expect
+        }
+        assertNull(getVersion);
+    }
+
+
+}

--- a/src/test/java/net/smartcosmos/dto/metadata/MetadataUpsertTest.java
+++ b/src/test/java/net/smartcosmos/dto/metadata/MetadataUpsertTest.java
@@ -1,0 +1,35 @@
+package net.smartcosmos.dto.metadata;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class MetadataUpsertTest {
+
+    @Test
+    public void thatVersionIsSet() {
+        MetadataUpsert entity = MetadataUpsert.builder().build();
+
+        assertNotNull(entity.getVersion());
+        assertEquals(1, entity.getVersion());
+    }
+
+    /**
+     * This actually tests if Lombok is properly used.
+     */
+    @Test
+    public void thatVersionHasNoSetter() {
+        Method getVersion = null;
+        try {
+            getVersion = MetadataUpsert.class.getDeclaredMethod("setVersion", int.class);
+        } catch (NoSuchMethodException e) {
+            // that's what we expect
+        }
+        assertNull(getVersion);
+    }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

The read-only `version` field is added to the Metadata DTOs.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

Nothing.
