### PR TITLE
Bugfix/null metadata map

### DIFF
--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataCreate.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataCreate.java
@@ -1,22 +1,18 @@
 package net.smartcosmos.dto.metadata;
 
-import java.beans.ConstructorProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
+import lombok.Data;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Setter;
-
 @Data
-@Builder
 @JsonIgnoreProperties(value = {"version"}, ignoreUnknown = true)
 public class MetadataCreate {
     private static final int VERSION = 1;
 
-    private final int version = VERSION; // just in case there is a default constructor sometime
+    private final int version = VERSION;
 
     private String ownerType;
 
@@ -24,4 +20,15 @@ public class MetadataCreate {
 
     private Map<String, Object> metadata;
 
+    @Builder
+    @java.beans.ConstructorProperties({"ownerType", "ownerUrn", "metadata"})
+    public MetadataCreate(String ownerType, String ownerUrn, Map<String, Object> metadata) {
+        this.ownerType = ownerType;
+        this.ownerUrn = ownerUrn;
+
+        this.metadata = new HashMap<>();
+        if (metadata != null) {
+            this.metadata.putAll(metadata);
+        }
+    }
 }

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataQuery.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataQuery.java
@@ -1,12 +1,8 @@
 package net.smartcosmos.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Setter;
-
-import java.beans.ConstructorProperties;
 
 @Data
 @Builder
@@ -15,7 +11,7 @@ public class MetadataQuery {
 
     private static final int VERSION = 1;
 
-    private final int version = VERSION; // just in case there is a default constructor sometime
+    private final int version = VERSION;
 
     private String entityReferenceType;
     private String key;

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataResponse.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataResponse.java
@@ -1,33 +1,41 @@
 package net.smartcosmos.dto.metadata;
 
-import java.beans.ConstructorProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Setter;
-
 @Data
-@Builder
-@JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonIgnoreProperties({"version"})
 public class MetadataResponse {
 
     private static final int VERSION = 1;
 
-    private final int version = VERSION; // just in case there is a default constructor sometime
+    private final int version = VERSION;
 
     private final String ownerType;
 
     private final String ownerUrn;
 
-    private Map<String, Object> metadata;
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Map<String, Object> metadata;
 
     private final String tenantUrn;
 
+    @Builder
+    @java.beans.ConstructorProperties({"ownerType", "ownerUrn", "metadata", "tenantUrn"})
+    public MetadataResponse(String ownerType, String ownerUrn, Map<String, Object> metadata, String tenantUrn) {
+        this.ownerType = ownerType;
+        this.ownerUrn = ownerUrn;
+        this.tenantUrn = tenantUrn;
+
+        this.metadata = new HashMap<>();
+        if (metadata != null) {
+            this.metadata.putAll(metadata);
+        }
+    }
 }
 

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataSingleResponse.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataSingleResponse.java
@@ -1,13 +1,9 @@
 package net.smartcosmos.dto.metadata;
 
-import java.beans.ConstructorProperties;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Setter;
 
 /**
  * This response model is particularly intended to be used for Query Requests, i.e. with paging.
@@ -35,5 +31,4 @@ public class MetadataSingleResponse {
     private final Object value;
 
     private final String tenantUrn;
-
 }

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataUpdate.java
@@ -1,14 +1,8 @@
 package net.smartcosmos.dto.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Setter;
-
-import java.beans.ConstructorProperties;
-import java.util.HashMap;
-import java.util.Map;
 
 @Data
 @Builder
@@ -17,7 +11,7 @@ public class MetadataUpdate
 {
     private static final int VERSION = 1;
 
-    private final int version = VERSION; // just in case there is a default constructor sometime
+    private final int version = VERSION;
 
     private String ownerType;
 
@@ -26,5 +20,4 @@ public class MetadataUpdate
     private String key;
 
     private String value;
-
 }

--- a/src/main/java/net/smartcosmos/dto/metadata/MetadataUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/metadata/MetadataUpdate.java
@@ -19,5 +19,5 @@ public class MetadataUpdate
 
     private String key;
 
-    private String value;
+    private Object value;
 }

--- a/src/test/java/net/smartcosmos/dto/metadata/MetadataCreateTest.java
+++ b/src/test/java/net/smartcosmos/dto/metadata/MetadataCreateTest.java
@@ -73,4 +73,14 @@ public class MetadataCreateTest {
         assertNotNull(jsonObject.get("metadata"));
     }
 
+    @Test
+    public void thatBuilderAcceptsNullMetadata() {
+        MetadataCreate response = MetadataCreate.builder()
+            .metadata(null)
+            .build();
+
+        assertNotNull(response);
+        assertNotNull(response.getMetadata());
+        assertTrue(response.getMetadata().isEmpty());
+    }
 }

--- a/src/test/java/net/smartcosmos/dto/metadata/MetadataResponseTest.java
+++ b/src/test/java/net/smartcosmos/dto/metadata/MetadataResponseTest.java
@@ -74,4 +74,15 @@ public class MetadataResponseTest {
         assertTrue(jsonObject.has("metadata"));
         assertNotNull(jsonObject.get("metadata"));
     }
+
+    @Test
+    public void thatBuilderAcceptsNullMetadata() {
+        MetadataResponse response = MetadataResponse.builder()
+            .metadata(null)
+            .build();
+
+        assertNotNull(response);
+        assertNotNull(response.getMetadata());
+        assertTrue(response.getMetadata().isEmpty());
+    }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Add the annotated constructor again to initialize the `metadata` map with an empty `HashMap` to prevent `NullPointerException`.
- Change `value` type to consistently be `Object`
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

(If this pull request depends on any pull requests, please paste them here, those pull requests will automatically reference this one, so no need to reference it there.)
