### PR TITLE
added findByKeyNoTenant

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/MetadataDao.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/MetadataDao.java
@@ -107,6 +107,16 @@ public interface MetadataDao {
     Optional<MetadataValueResponse> findByKey(String tenantUrn, String ownerType, String ownerUrn, String key);
 
     /**
+     * Finds a metadata entity for an associated entity matching a specified key, regardless of tenant.
+     *
+     * @param ownerType the reference type of the associated entities
+     * @param ownerUrn the URN of the associated entity
+     * @param key the key of the metadata entity
+     * @return the value Object assigned to the given key or Optional.empty() in case of a non-existing key
+     */
+    Optional<MetadataValueResponse> findByKeyNoTenant(String ownerType, String ownerUrn, String key);
+
+    /**
      * Find all metadata owned by a thing in the realm of a given tenant.
      *
      * @param tenantUrn the tenant URN


### PR DESCRIPTION
### What changes were proposed in this pull request?
- add support for GET /{ownerType}/{ownerUrn}/{key}?ignoreUserTenant={ignoreUserTenant}&tenantUrn={tenantUrn} on the DAO interface, when ignoreUserTenant = true and tenantUrn is empty
- this fixes the problem of some PROFILES services to read metadata of a thing independently of the tenant
### How is this patch documented?

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-ext-metadata-rdao/blob/bugfix/PROFILES-706/README.adoc#read1

The service uses following rule to look up a metadata key:
1. when the user has https://authorities.smartcosmos.net/metadata/ignoreUserTenant authority and ignoreUserTenant is set to true
  a) if tenantUrn is given: return metadata of the thing defined by type, urn in the given tenant
  b) if tenantUrn is empty: return metadata of the thing defined by type, urn in any tenant
2. when the user does not have this authority or ignoreUserTenant is false:
return metadata of the thing defined by type, urn in the tenant related to the user's login credentials
### How was this patch tested?
- This is interface only
#### Depends On
- None, but other pull requests depend on this.
